### PR TITLE
Fix issue on AAC audio codec

### DIFF
--- a/src/accessories/streamingDelegate.ts
+++ b/src/accessories/streamingDelegate.ts
@@ -410,7 +410,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
             (request.audio.codec === AudioStreamingCodecType.OPUS ?
               ' -codec:a libopus' +
               ' -application lowdelay' :
-              ' -codec:a libfdk_aac' +
+              ' -codec:a aac' +
               ' -profile:a aac_eld') +
             ' -flags +global_header' +
             ' -f null' +
@@ -461,7 +461,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
           '-hide_banner' +
           ' -protocol_whitelist pipe,udp,rtp,file,crypto' +
           ' -f sdp' +
-          ' -c:a libfdk_aac' +
+          ' -c:a aac' +
           ' -i pipe:' +
           ' ' + this.videoConfig.returnAudioTarget +
           ' -loglevel level' + (this.videoConfig.debugReturn ? '+verbose' : '');


### PR DESCRIPTION
### Fixed 
- Fix issue on AAC audio codec
  - As per FFMPEG team, libfacc has been removed since 2016. I can see on the log that this was creating a lot issue while streaming. Switching for the supported one.
  - https://git.videolan.org/gitweb.cgi/ffmpeg.git/?a=commit;h=dc0f711459e0c682bf9f94ba38d26736e90cff45